### PR TITLE
bugfix: /my-profile page: warning always shown when refreshing

### DIFF
--- a/web/src/pages/my-profile/[tab]/index.jsx
+++ b/web/src/pages/my-profile/[tab]/index.jsx
@@ -21,7 +21,7 @@ import { nl2br } from 'claptime/utils/i18n';
 
 const MyProfilePage = () => {
   const user = useUserState();
-  const [showWarning, setShowWarning] = useState(!user.hasPublicProfile);
+  const [validated, setValidated] = useState(false);
   const [acknowledged, setAcknowledged] = useState(false);
   const { t } = useTranslation();
   const { response, items: collections } = useQueryList(
@@ -35,7 +35,7 @@ const MyProfilePage = () => {
           },
         },
       },
-      skip: !user.hasPublicProfile,
+      skip: user.loaded && !user.hasPublicProfile,
     },
     {
       resultPath: '$.listCollections',
@@ -45,7 +45,7 @@ const MyProfilePage = () => {
   if (!useIsAuthenticated()) return <Spin />;
   if (response) return response;
 
-  if (showWarning) {
+  if (!user.hasPublicProfile && !validated) {
     return (
       <>
         <Head page="my-profile" />
@@ -68,7 +68,7 @@ const MyProfilePage = () => {
                 <Button
                   type="primary"
                   disabled={!acknowledged}
-                  onClick={() => setShowWarning(false)}
+                  onClick={() => setValidated(true)}
                 >
                   {t('myProfilePage.container.createProfileButton')}
                 </Button>


### PR DESCRIPTION
`listCollections` query was skipped when `!user.hasPublicProfile`, which is false while user is not loaded yet.
The warning was always displayed when refreshing the page, even for users with a public profile.