### PR TITLE
bugfix: /my-payments page, Strie query not triggered

### DIFF
--- a/web/src/components/molecules/RoutedTabs/index.jsx
+++ b/web/src/components/molecules/RoutedTabs/index.jsx
@@ -10,7 +10,7 @@ import PageHeader from 'claptime/components/molecules/PageHeader';
 const RoutedTabs = ({ actions, basePath, tabs, i18nBasePath }) => {
   const { t } = useTranslation();
   const { asPath } = useRouter();
-  const currentKey = asPath.split('/').pop();
+  const currentKey = asPath.split('/').pop().split('?')[0];
 
   const pageTitle = (
     <span>

--- a/web/src/components/organisms/StripeConnection/index.jsx
+++ b/web/src/components/organisms/StripeConnection/index.jsx
@@ -24,27 +24,21 @@ const StripeConnection = ({ queryString }) => {
   const { t } = useTranslation();
   const { settings, isLoggedIn } = useUserState();
   const apolloClient = useApolloClient();
-  const [profileId, setProfileId] = useState(null);
+
+  const { profileId } = settings;
+
   const { loading, item, error, refetch, response, run } = useQueryGet(
     getStripeAccessToken,
     {
       variables: { profileId },
     },
     {
-      resultPath: '$.getStripeAccessToken',
-      lazy: true,
+      resultPath: '$.getStripeAccessToken'
     },
   );
 
   if (!isLoggedIn) {
     return null;
-  }
-
-  if (!profileId && settings && settings.profileId) {
-    setProfileId(settings.profileId);
-    run();
-  } else if (!profileId || loading) {
-    return <Spin />;
   }
 
   if (response) return response;

--- a/web/src/components/organisms/StripeConnection/index.jsx
+++ b/web/src/components/organisms/StripeConnection/index.jsx
@@ -1,5 +1,5 @@
 // https://stripe.com/docs/connect/standard-accounts
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Popconfirm, message } from 'antd';
 import { ApiOutlined } from '@ant-design/icons';
 import { gql } from '@apollo/client';
@@ -27,13 +27,13 @@ const StripeConnection = ({ queryString }) => {
 
   const { profileId } = settings;
 
-  const { loading, item, error, refetch, response, run } = useQueryGet(
+  const { item, error, refetch, response } = useQueryGet(
     getStripeAccessToken,
     {
       variables: { profileId },
     },
     {
-      resultPath: '$.getStripeAccessToken'
+      resultPath: '$.getStripeAccessToken',
     },
   );
 


### PR DESCRIPTION
`getStripeAccessToken` : normal query can be used instead of a lazy query